### PR TITLE
Fix redundant license update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### :syringe: Fixed
+
+- [#59](https://github.com/FantasticFiasco/action-update-license-year/issues/59) Single year in license is updated into a range of years even though year hasn't changed (discovered by [@tenshiAMD](https://github.com/tenshiAMD))
+
 ## [1.2.1] - 2020-07-19
 
 ### :syringe: Fixed
@@ -28,7 +32,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - Update action metadata with required `token` input
 - [#42](https://github.com/FantasticFiasco/action-update-license-year/issues/42) Improve error message displayed when license file doesn't exist in repository
-- [#40](https://github.com/FantasticFiasco/action-update-license-year/issues/40) Only create pull request if license is updated
+- [#40](https://github.com/FantasticFiasco/action-update-license-year/issues/40) Only create pull request if license is updated (discovered by [@spl](https://github.com/spl))
 
 ## [1.1.2] - 2020-05-01
 

--- a/src/license.js
+++ b/src/license.js
@@ -1,20 +1,20 @@
 // Regular expressions finding the copyright year(s) in GNU Affero General Public License v3.0 only
 // (AGPL-3.0-only) license files
-const GNU_AGPLv3_COPYRIGHT_YEAR = /(Copyright\s+\(C\)\s+)(\d{4})(?!\s+Free Software Foundation)(\s+\w+)/gm;
-const GNU_AGPLv3_COPYRIGHT_YEAR_RANGE = /(Copyright\s+\(C\)\s+)(\d{4})-(\d{4})(?!\s+Free Software Foundation)(\s+\w+)/gm;
+const GNU_AGPLv3_COPYRIGHT_YEAR = /(Copyright\s+\(C\)\s+)(\d{4})(?!\s+Free Software Foundation)(\s+\w+)/m;
+const GNU_AGPLv3_COPYRIGHT_YEAR_RANGE = /(Copyright\s+\(C\)\s+)(\d{4})-(\d{4})(?!\s+Free Software Foundation)(\s+\w+)/m;
 
 // Regular expressions finding the copyright year(s) in Apache 2.0 (Apache-2.0) license files
-const APACHE_COPYRIGHT_YEAR = /(Copyright\s+)(\d{4})(\s+\w+)/gm;
-const APACHE_COPYRIGHT_YEAR_RANGE = /(Copyright\s+)(\d{4})-(\d{4})(\s+\w+)/gm;
+const APACHE_COPYRIGHT_YEAR = /(Copyright\s+)(\d{4})(\s+\w+)/m;
+const APACHE_COPYRIGHT_YEAR_RANGE = /(Copyright\s+)(\d{4})-(\d{4})(\s+\w+)/m;
 
 // Regular expressions finding the copyright year(s) in BSD 2-clause "Simplified" (BSD-2-Clause)
 // and BSD 3-clause "New" or "Revised" (BSD-3-Clause) license files
-const BSD_COPYRIGHT_YEAR = /(Copyright\s+\(c\)\s+)(\d{4})(,\s+\w+)/gm;
-const BSD_COPYRIGHT_YEAR_RANGE = /(Copyright\s+\(c\)\s+)(\d{4})-(\d{4})(,\s+\w+)/gm;
+const BSD_COPYRIGHT_YEAR = /(Copyright\s+\(c\)\s+)(\d{4})(,\s+\w+)/m;
+const BSD_COPYRIGHT_YEAR_RANGE = /(Copyright\s+\(c\)\s+)(\d{4})-(\d{4})(,\s+\w+)/m;
 
 // Regular expressions finding the copyright year(s) in MIT (MIT) license files
-const MIT_COPYRIGHT_YEAR = /(Copyright\s+\(c\)\s+)(\d{4})(\s+\w+)/gm;
-const MIT_COPYRIGHT_YEAR_RANGE = /(Copyright\s+\(c\)\s+)(\d{4})-(\d{4})(\s+\w+)/gm;
+const MIT_COPYRIGHT_YEAR = /(Copyright\s+\(c\)\s+)(\d{4})(\s+\w+)/m;
+const MIT_COPYRIGHT_YEAR_RANGE = /(Copyright\s+\(c\)\s+)(\d{4})-(\d{4})(\s+\w+)/m;
 
 /**
  * @param {string} license
@@ -30,7 +30,11 @@ function updateLicense(license) {
  */
 function updateLicenseToYear(license, year) {
     // GNU Affero General Public License v3.0 only
-    if (GNU_AGPLv3_COPYRIGHT_YEAR.test(license)) {
+    let match = GNU_AGPLv3_COPYRIGHT_YEAR.exec(license);
+    if (match !== null) {
+        if (isYearUnchanged(match, year)) {
+            return license;
+        }
         return license.replace(GNU_AGPLv3_COPYRIGHT_YEAR, `$1$2-${year}$3`);
     }
     if (GNU_AGPLv3_COPYRIGHT_YEAR_RANGE.test(license)) {
@@ -38,7 +42,11 @@ function updateLicenseToYear(license, year) {
     }
 
     // Apache 2.0
-    if (APACHE_COPYRIGHT_YEAR.test(license)) {
+    match = APACHE_COPYRIGHT_YEAR.exec(license);
+    if (match !== null) {
+        if (isYearUnchanged(match, year)) {
+            return license;
+        }
         return license.replace(APACHE_COPYRIGHT_YEAR, `$1$2-${year}$3`);
     }
     if (APACHE_COPYRIGHT_YEAR_RANGE.test(license)) {
@@ -47,7 +55,11 @@ function updateLicenseToYear(license, year) {
 
     // BSD 2-clause "Simplified"
     // BSD 3-clause "New" or "Revised"
-    if (BSD_COPYRIGHT_YEAR.test(license)) {
+    match = BSD_COPYRIGHT_YEAR.exec(license);
+    if (match !== null) {
+        if (isYearUnchanged(match, year)) {
+            return license;
+        }
         return license.replace(BSD_COPYRIGHT_YEAR, `$1$2-${year}$3`);
     }
     if (BSD_COPYRIGHT_YEAR_RANGE.test(license)) {
@@ -55,7 +67,11 @@ function updateLicenseToYear(license, year) {
     }
 
     // MIT
-    if (MIT_COPYRIGHT_YEAR.test(license)) {
+    match = MIT_COPYRIGHT_YEAR.exec(license);
+    if (match !== null) {
+        if (isYearUnchanged(match, year)) {
+            return license;
+        }
         return license.replace(MIT_COPYRIGHT_YEAR, `$1$2-${year}$3`);
     }
     if (MIT_COPYRIGHT_YEAR_RANGE.test(license)) {
@@ -63,6 +79,16 @@ function updateLicenseToYear(license, year) {
     }
 
     throw new Error('Specified license is not supported');
+}
+
+/**
+ *
+ * @param {string[]} match
+ * @param {number} year
+ */
+function isYearUnchanged(match, year) {
+    const yearInLicense = Number(match[2]);
+    return yearInLicense === year;
 }
 
 module.exports = {

--- a/test/license.spec.js
+++ b/test/license.spec.js
@@ -15,6 +15,12 @@ describe('#updateToYear should', () => {
         expect(got).toBe(want);
     });
 
+    test('not update GNU Affero General Public License v3.0 only license from a single year given year is unchanged', () => {
+        const got = updateLicenseToYear(readTestFile('AGPL-3.0-only/SINGLE_YEAR'), 2000);
+        const want = readTestFile('AGPL-3.0-only/SINGLE_YEAR');
+        expect(got).toBe(want);
+    });
+
     test('update GNU Affero General Public License v3.0 only license from a range of years into a new range of years', () => {
         const got = updateLicenseToYear(readTestFile('AGPL-3.0-only/RANGE_OF_YEARS'), 2002);
         const want = readTestFile('AGPL-3.0-only/RANGE_OF_YEARS_EXPECTED');
@@ -24,6 +30,12 @@ describe('#updateToYear should', () => {
     test('update Apache 2.0 license from a single year into a range of years', () => {
         const got = updateLicenseToYear(readTestFile('Apache-2.0/SINGLE_YEAR'), 2002);
         const want = readTestFile('Apache-2.0/SINGLE_YEAR_EXPECTED');
+        expect(got).toBe(want);
+    });
+
+    test('not update Apache 2.0 license from a single year given year is unchanged', () => {
+        const got = updateLicenseToYear(readTestFile('Apache-2.0/SINGLE_YEAR'), 2000);
+        const want = readTestFile('Apache-2.0/SINGLE_YEAR');
         expect(got).toBe(want);
     });
 
@@ -39,6 +51,12 @@ describe('#updateToYear should', () => {
         expect(got).toBe(want);
     });
 
+    test('not update BSD 2-clause "Simplified" license from a single year given year is unchanged', () => {
+        const got = updateLicenseToYear(readTestFile('BSD-2-Clause/SINGLE_YEAR'), 2000);
+        const want = readTestFile('BSD-2-Clause/SINGLE_YEAR');
+        expect(got).toBe(want);
+    });
+
     test('update BSD 2-clause "Simplified" license from a range of years into a new range of years', () => {
         const got = updateLicenseToYear(readTestFile('BSD-2-Clause/RANGE_OF_YEARS'), 2002);
         const want = readTestFile('BSD-2-Clause/RANGE_OF_YEARS_EXPECTED');
@@ -51,6 +69,12 @@ describe('#updateToYear should', () => {
         expect(got).toBe(want);
     });
 
+    test('not update BSD 3-clause "New" or "Revised" license from a single year given year is unchanged', () => {
+        const got = updateLicenseToYear(readTestFile('BSD-3-Clause/SINGLE_YEAR'), 2000);
+        const want = readTestFile('BSD-3-Clause/SINGLE_YEAR');
+        expect(got).toBe(want);
+    });
+
     test('update BSD 3-clause "New" or "Revised" license from a range of years into a new range of years', () => {
         const got = updateLicenseToYear(readTestFile('BSD-3-Clause/RANGE_OF_YEARS'), 2002);
         const want = readTestFile('BSD-3-Clause/RANGE_OF_YEARS_EXPECTED');
@@ -60,6 +84,12 @@ describe('#updateToYear should', () => {
     test('update MIT license from a single year into a range of years', () => {
         const got = updateLicenseToYear(readTestFile('MIT/SINGLE_YEAR'), 2002);
         const want = readTestFile('MIT/SINGLE_YEAR_EXPECTED');
+        expect(got).toBe(want);
+    });
+
+    test('not update MIT license from a single year given year is unchanged', () => {
+        const got = updateLicenseToYear(readTestFile('MIT/SINGLE_YEAR'), 2000);
+        const want = readTestFile('MIT/SINGLE_YEAR');
         expect(got).toBe(want);
     });
 


### PR DESCRIPTION
Single year in license is updated into a range of years even though year hasn't changed.

Closes #59