### PR TITLE
Allow utf-8 characters in LICENSE owners names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### :syringe: Fixed
+
+- [#97](https://github.com/FantasticFiasco/action-update-license-year/pull/97) License file is incorrectly updated using ASCII encoding instead of UTF8 (contributed by [@mondeja](https://github.com/mondeja))
+
 ## [1.4.1] - 2020-09-22
 
 ### :policeman: Security

--- a/dist/index.js
+++ b/dist/index.js
@@ -428,7 +428,7 @@ async function run() {
             info(`Found branch named "${branchName}"`);
         }
         const licenseResponse = await repository.getContent(hasBranch ? branchName : MASTER, FILENAME);
-        const license = Buffer.from(licenseResponse.data.content, 'base64').toString('utf8');
+        const license = Buffer.from(licenseResponse.data.content, 'base64').toString('ascii');
 
         const currentYear = new Date().getFullYear();
         info(`Current year is "${currentYear}"`);
@@ -1433,7 +1433,7 @@ class Repository {
      * @param {string} branchName The branch name
      * @param {string} filePath The file path
      * @param {string} sha The blob SHA of the file being replaced
-     * @param {string} content The new file content, using UTF8 encoding
+     * @param {string} content The new file content, using ASCII encoding
      * @param {string} commitMessage The commit message
      */
     async updateContent(branchName, filePath, sha, content, commitMessage) {
@@ -1444,7 +1444,7 @@ class Repository {
                 branch: branchName,
                 path: filePath,
                 message: commitMessage,
-                content: Buffer.from(content, 'utf8').toString('base64'),
+                content: Buffer.from(content, 'ascii').toString('base64'),
                 sha,
             });
         } catch (err) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -428,7 +428,7 @@ async function run() {
             info(`Found branch named "${branchName}"`);
         }
         const licenseResponse = await repository.getContent(hasBranch ? branchName : MASTER, FILENAME);
-        const license = Buffer.from(licenseResponse.data.content, 'base64').toString('ascii');
+        const license = Buffer.from(licenseResponse.data.content, 'base64').toString('utf8');
 
         const currentYear = new Date().getFullYear();
         info(`Current year is "${currentYear}"`);
@@ -1433,7 +1433,7 @@ class Repository {
      * @param {string} branchName The branch name
      * @param {string} filePath The file path
      * @param {string} sha The blob SHA of the file being replaced
-     * @param {string} content The new file content, using ASCII encoding
+     * @param {string} content The new file content, using UTF8 encoding
      * @param {string} commitMessage The commit message
      */
     async updateContent(branchName, filePath, sha, content, commitMessage) {
@@ -1444,7 +1444,7 @@ class Repository {
                 branch: branchName,
                 path: filePath,
                 message: commitMessage,
-                content: Buffer.from(content, 'ascii').toString('base64'),
+                content: Buffer.from(content, 'utf8').toString('base64'),
                 sha,
             });
         } catch (err) {

--- a/src/Repository.js
+++ b/src/Repository.js
@@ -87,7 +87,7 @@ class Repository {
      * @param {string} branchName The branch name
      * @param {string} filePath The file path
      * @param {string} sha The blob SHA of the file being replaced
-     * @param {string} content The new file content, using ASCII encoding
+     * @param {string} content The new file content, using UTF8 encoding
      * @param {string} commitMessage The commit message
      */
     async updateContent(branchName, filePath, sha, content, commitMessage) {
@@ -98,7 +98,7 @@ class Repository {
                 branch: branchName,
                 path: filePath,
                 message: commitMessage,
-                content: Buffer.from(content, 'ascii').toString('base64'),
+                content: Buffer.from(content, 'utf8').toString('base64'),
                 sha,
             });
         } catch (err) {

--- a/src/action-update-license-year.js
+++ b/src/action-update-license-year.js
@@ -27,7 +27,7 @@ async function run() {
             info(`Found branch named "${branchName}"`);
         }
         const licenseResponse = await repository.getContent(hasBranch ? branchName : MASTER, FILENAME);
-        const license = Buffer.from(licenseResponse.data.content, 'base64').toString('ascii');
+        const license = Buffer.from(licenseResponse.data.content, 'base64').toString('utf8');
 
         const currentYear = new Date().getFullYear();
         info(`Current year is "${currentYear}"`);

--- a/test/Repository.spec.js
+++ b/test/Repository.spec.js
@@ -123,6 +123,15 @@ describe('#updateContent should', () => {
         await expect(promise).resolves.toBeDefined();
     });
 
+    test('use utf8 encoding', async () => {
+        mockOctokit.repos.createOrUpdateFileContents.mockResolvedValue({});
+        const repository = new Repository('some owner', 'some name', 'some token');
+        const content = 'Álvaro Mondéjar';
+        const promise = repository.updateContent('master', 'LICENSE', 'some sha', content, 'some commit message');
+        await expect(promise).resolves.toBeDefined();
+        expect(fromBase64ToUtf8(mockOctokit.repos.createOrUpdateFileContents.mock.calls[0][0].content)).toBe(content);
+    });
+
     test("throw error given file doesn't exist", async () => {
         mockOctokit.repos.createOrUpdateFileContents.mockRejectedValue({});
         const repository = new Repository('some owner', 'some name', 'some token');
@@ -223,4 +232,11 @@ const GET_REF_SUCCESS_RESPONSE = {
 
 const GET_REF_FAILURE_RESPONSE = {
     status: 404,
+};
+
+/**
+ * @param {string} value
+ */
+const fromBase64ToUtf8 = (value) => {
+    return Buffer.from(value, 'base64').toString('utf8');
 };


### PR DESCRIPTION
# Description

I've tested this action and [this is the result](https://github.com/mondeja/test-update-license-cr-year-action/pull/1/files) that is trying to push. My name "Álvaro Mondéjar" has UTF-8 characters that has been converted to ASCII ones resulting in "Clvaro MondC)jar".

# Checklist

- [x] I have squashed my commits into a single one with a message that aligns with the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
