### PR TITLE
Prevent autogenerated trailing whitespaces in README

### DIFF
--- a/scripts/generate-docs.js
+++ b/scripts/generate-docs.js
@@ -102,7 +102,7 @@ const updateUsage = () => {
         if (input.default !== undefined) {
             let defaultLine = '    # Default:';
             if (input.default !== '') {
-              defaultLine += ` ${input.default}`;
+                defaultLine += ` ${input.default}`;
             }
             newReadme.push(defaultLine);
         }

--- a/scripts/generate-docs.js
+++ b/scripts/generate-docs.js
@@ -100,7 +100,11 @@ const updateUsage = () => {
 
         // Default
         if (input.default !== undefined) {
-            newReadme.push(`    # Default: ${input.default}`);
+            let defaultLine = '    # Default:';
+            if (input.default !== '') {
+              defaultLine += ` ${input.default}`;
+            }
+            newReadme.push(defaultLine);
         }
 
         // Input name


### PR DESCRIPTION
# Description

Minor change in the documentation generator script to prevent [autogeneration of trailing whitespaces](https://github.com/FantasticFiasco/action-update-license-year/pull/139/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L119).
