### PR TITLE
fix: typo on update abort log

### DIFF
--- a/src/action-update-license-year.js
+++ b/src/action-update-license-year.js
@@ -59,7 +59,7 @@ const run = async () => {
         }
 
         if (!repo.hasChanges()) {
-            info(`No licenses where updated, let's abort`);
+            info(`No licenses were updated, let's abort`);
             return;
         }
 


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

This pull request fixes a typo:

from `info('No licenses where updated, let's abort ');`

to `info( 'No licenses were updated, let's abort');`

# Checklist

- [x] I have squashed my commits into a single one with a message that aligns with the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
