### PR TITLE
Migrate from using deprecated functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "devDependencies": {
     "@types/jest": "29.5.1",
     "@types/js-yaml": "4.0.5",
+    "@types/node": "20.1.3",
     "@vercel/ncc": "0.36.1",
     "eslint": "8.39.0",
     "jest": "29.5.0",

--- a/test/file.test.js
+++ b/test/file.test.js
@@ -53,8 +53,8 @@ describe('#search', () => {
         fs.writeFileSync(path.join(tempDir, 'packages', 'c', 'index.js'), 'some content')
     })
 
-    afterAll(() => {
-        fs.rmdirSync(tempDir, {
+    afterAll(async () => {
+        await fs.promises.rm(tempDir, {
             recursive: true,
         })
     })

--- a/test/repository.test.js
+++ b/test/repository.test.js
@@ -50,8 +50,8 @@ beforeEach(async () => {
     jest.resetAllMocks()
 })
 
-afterEach(() => {
-    fs.rmdirSync(tempRepoDir, {
+afterEach(async () => {
+    await fs.promises.rm(tempRepoDir, {
         recursive: true,
     })
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,14 @@
 {
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig.json to read more about this file */
-
-    "target": "ES2017",
+    "target": "ES2021",
     "module": "commonjs",
     "allowJs": true,
     "checkJs": true,
-
     "strict": true,
-
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "lib": ["ES2021"]
   },
   "exclude": ["./coverage/*", "./dist/*"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1264,6 +1264,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.4.tgz#1581d6c16e3d4803eb079c87d4ac893ee7501c2c"
   integrity sha512-x26ur3dSXgv5AwKS0lNfbjpCakGIduWU1DU91Zz58ONRWrIKGunmZBNv4P7N+e27sJkiGDsw/3fT4AtsqQBrBA==
 
+"@types/node@20.1.3":
+  version "20.1.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.1.3.tgz#bc8e7cd8065a5fc355a3a191a68db8019c58bc00"
+  integrity sha512-NP2yfZpgmf2eDRPmgGq+fjGjSwFgYbihA8/gK+ey23qT9RkxsgNTZvGOEpXgzIGqesTYkElELLgtKoMQTys5vA==
+
 "@types/node@>= 8":
   version "13.1.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.1.1.tgz#6d11a8c2d58405b3db9388ab740106cbfa64c3c9"


### PR DESCRIPTION
# Description

Let's migrate away from using a deprecated function in Node.js.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
